### PR TITLE
Add support for Nessus > 7.x protected APIs.

### DIFF
--- a/lib/nessus_rest.rb
+++ b/lib/nessus_rest.rb
@@ -149,7 +149,11 @@ module NessusREST
       res = http_post(:uri=>"/session", :data=>payload)
       if res['token']
         @token = "token=#{res['token']}"
-        @x_cookie = {'X-Cookie'=>@token}
+        # Starting from Nessus 7.x, Tenable protects some endpoints with a custom header
+        # so that they can only be called from the user interface (supposedly).
+        res = http_get({:uri=>"/nessus6.js", :raw_content=> true})
+        @api_token = res.scan(/([A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12})/).first.last
+        @x_cookie = {'X-Cookie'=>@token, 'X-API-Token'=> @api_token}
         return true
       else
         false

--- a/lib/nessus_rest.rb
+++ b/lib/nessus_rest.rb
@@ -152,7 +152,7 @@ module NessusREST
         # Starting from Nessus 7.x, Tenable protects some endpoints with a custom header
         # so that they can only be called from the user interface (supposedly).
         res = http_get({:uri=>"/nessus6.js", :raw_content=> true})
-        @api_token = res.scan(/([A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12})/).first.last
+        @api_token = res.scan(/([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})/).first.last
         @x_cookie = {'X-Cookie'=>@token, 'X-API-Token'=> @api_token}
         return true
       else


### PR DESCRIPTION
Starting from Nessus version 7.x and onward, Tenable chose to protects specific APIs. The idea was to protect them from being called outside the Nessus web interface.

This protection is implemented by adding a custom HTTP header (`X-Api-Token`) set to a value obtained from Nessus client-side JavaScript code (`nessus6.js`).

You can check which APIs are protected by going to `/api` on your scanner web interface. Protected API have this blue mention on top:

![screenshot from 2019-01-12 13-25-36](https://user-images.githubusercontent.com/569494/51073284-cfcc5800-166e-11e9-829f-b5b8601a4963.png)

This is problematic because it breaks multiple tools such as Metasploit integration with Nessus. While most API calls still works (get users, get scans, get policies), state altering requests (e.g. create/launch/pause/stop/delete scans) do not work anymore.

This pull requests fix this by obtaining the token value once the user is successfully authenticated, then  the token is submitted on all subsequent requests in a similar manner than `X-Cookie` is.

This was tested against Nessus 7.1 and Nessus 8.1.1